### PR TITLE
fix(Home.module.css): fix image overlapping text

### DIFF
--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -77,6 +77,7 @@
 
 .carousel .card {
 	margin: 1rem;
+	margin-top: 250px;
 	padding: 1rem;
 	border: 2px solid rgb(238, 238, 238);
 	border-radius: 10px;


### PR DESCRIPTION
* Add **top margin** to prevent carousel images from overlapping text in **desktop view**
* Fixes #87 