### PR TITLE
add <br> for medium screens where buttons are not visible and edit cs…

### DIFF
--- a/pages/opensource.js
+++ b/pages/opensource.js
@@ -67,8 +67,11 @@ export default function Guide() {
             </div>
           </section>
         </div>
+        <br></br>
+        <br></br>
+        <br></br>
+        <br></br>
       </main>
-
       <Footer />
     </div>
   );

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -62,8 +62,7 @@
 .duoGrid .aboutScroll {
 	overflow-y: scroll;
 	padding: 1em 1em;
-	margin-top: 3em;
-	margin-bottom: 3em;
+	margin: 3em 0;
 }
 
 .carousel {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -163,7 +163,6 @@ footer {
 	border: 1px solid rgba(240, 232, 232, 0.096);
 	/* margin-top: 47% ; */
 	right: 0;
-	bottom: 1%;
 }
 footer a {
 	text-decoration: none;
@@ -257,5 +256,8 @@ footer a:hover{
 	}
 	footer{
 		width: 120%;
+	}
+	br{
+		display:none;
 	}
   }


### PR DESCRIPTION
-Added <br> tags to opensource page because buttons are not visible/reachable in medium non-4k regular laptop screens (you can't scroll down the page to see them because page finished unless there are more below buttons, which br satisfies)
-Edited CSS properties so br are not visible in mobile mode. Alsodeleted one of footer's bottom properties which were 2 conflicting ones. The 1% one was not working properly so I deleted them and left `bottom: 0 ` alone.